### PR TITLE
Fix "cannot find scenario:" on partially matching scenario names

### DIFF
--- a/src/main/java/com/microfocus/bdd/CucumberJvmHandler.java
+++ b/src/main/java/com/microfocus/bdd/CucumberJvmHandler.java
@@ -34,7 +34,8 @@ package com.microfocus.bdd;
 
 import com.microfocus.bdd.api.*;
 
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 public class CucumberJvmHandler implements BddFrameworkHandler {
@@ -178,12 +179,19 @@ java.lang.AssertionError
         if (!feature.getScenarios(sceName).isEmpty()) {
             return sceName;
         }
+        List<OctaneScenario> scenarioOutlinesWithMatchingPrefix = new ArrayList<>();
         for (OctaneScenario sce : feature.getScenarios()) {
             if (sceName.startsWith(sce.getOutlineName())) {
-                return (sce.getName());
+                scenarioOutlinesWithMatchingPrefix.add(sce);
             }
         }
-        return null;
+        if (! scenarioOutlinesWithMatchingPrefix.isEmpty()) {
+            scenarioOutlinesWithMatchingPrefix.sort((c1, c2) -> c2.getOutlineName().length() - c1.getOutlineName().length());
+            // return longest match, avoiding coincidental matches with shorter prefix
+            return scenarioOutlinesWithMatchingPrefix.get(0).getName();
+        } else {
+            return null;
+        }
     }
 
 /*


### PR DESCRIPTION
I changed CucumberJvmHandler locally to fix #19 : Instead of returning the first prefix match, I assume that there could be more than one. Considering all outlines having a common prefix, I sort by length descending and then take the first (longest one).

E.g. for an Outline name `AAAA` there could be testcase elements (corresponding with example executions) also for Outlines named `A`, `AA` and `AAA`:
- `A - Example #1.1`
- `A - Example #1.2`
- `AA - Example #1.1`
- `AA - Example #1.2`
- `AAA - Example #1.1`
- `AAAA - Example #1.1` **this one is correct**
- ~`AAAAA - Example #1.1`~ **no prefix / startsWith condition**