### PR TITLE
Get the feature that exactly matches a classname containing hyphens, then look for part-matches if no exact match found.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@
 .settings
 *.iml
 target/
-cucumber/
 *result.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 .settings
 *.iml
 target/
+cucumber/
 *result.xml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   
-  <groupId>epl.test.automation</groupId>
+  <groupId>com.microfocus.adm.almoctane.bdd</groupId>
   <artifactId>bdd2octane</artifactId>
   <version>1.1.8-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   
-  <groupId>com.microfocus.adm.almoctane.bdd</groupId>
+  <groupId>epl.test.automation</groupId>
   <artifactId>bdd2octane</artifactId>
-  <version>1.1.7-SNAPSHOT</version>
+  <version>1.1.8-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>bdd2octane</name>

--- a/src/main/java/com/microfocus/bdd/CucumberJvmHandler.java
+++ b/src/main/java/com/microfocus/bdd/CucumberJvmHandler.java
@@ -183,6 +183,16 @@ java.lang.AssertionError
         featureFile = featureFile.substring(0, lineNumIndex);
     }
 
+    private Optional<OctaneFeature> findMatchingFeature(OctaneFeatureLocator octaneFeatureLocator, String classname) {
+      Optional<OctaneFeature> octaneFeatureOpt;
+      try {
+        octaneFeatureOpt = octaneFeatureLocator.getOctaneFeatureByName(classname);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      return octaneFeatureOpt;
+    }
+
   @Override
   public Optional<String> getFeatureName(OctaneFeatureLocator... octaneFeatureLocator) {
     String classname = element.getAttribute("classname");
@@ -191,26 +201,15 @@ java.lang.AssertionError
     }
     if (octaneFeatureLocator != null && octaneFeatureLocator.length > 0) {
       Optional<OctaneFeature> octaneFeatureOpt;
-      //first attempt to find OctaneFeature based on exact match of classname
-      try {
-        octaneFeatureOpt = octaneFeatureLocator[0].getOctaneFeatureByName(classname);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      octaneFeatureOpt = findMatchingFeature(octaneFeatureLocator[0], classname);
       if (octaneFeatureOpt.isPresent()) {
         return Optional.of(classname);
       } else {
-        //attempt to find OctaneFeature based on match of classnamePart (removes hyphenated suffix)
         String classnamePart = classname;
         while (classnamePart.contains("-")) {
           int lastIndex = classnamePart.lastIndexOf("-");
           classnamePart = classnamePart.substring(0, lastIndex).trim();
-          try {
-            octaneFeatureOpt = octaneFeatureLocator[0].getOctaneFeatureByName(classnamePart);
-
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
+          octaneFeatureOpt = findMatchingFeature(octaneFeatureLocator[0], classnamePart);
           if (octaneFeatureOpt.isPresent()) {
             return Optional.of(classnamePart);
             }

--- a/src/main/java/com/microfocus/bdd/CucumberJvmHandler.java
+++ b/src/main/java/com/microfocus/bdd/CucumberJvmHandler.java
@@ -1,4 +1,4 @@
- /**
+/**
  *
  * Copyright 2021-2023 Open Text
  *
@@ -183,30 +183,42 @@ java.lang.AssertionError
         featureFile = featureFile.substring(0, lineNumIndex);
     }
 
-    @Override
-    public Optional<String> getFeatureName(OctaneFeatureLocator... octaneFeatureLocator) {
-        String classname = element.getAttribute("classname");
-        if (classname.isEmpty() || classname.equals("EMPTY_NAME") || classname.equals("Unknown")) {
-            return Optional.empty();
-        }
-        if (octaneFeatureLocator != null && octaneFeatureLocator.length > 0) {
-            Optional<OctaneFeature> octaneFeatureOpt;
-            String classnamePart = classname;
-            while (classnamePart.contains("-")) {
-                int lastIndex = classnamePart.lastIndexOf("-");
-                classnamePart = classnamePart.substring(0, lastIndex).trim();
-                try {
-                    octaneFeatureOpt = octaneFeatureLocator[0].getOctaneFeatureByName(classnamePart);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-                if (octaneFeatureOpt.isPresent()) {
-                    return Optional.of(classnamePart);
-                }
+  @Override
+  public Optional<String> getFeatureName(OctaneFeatureLocator... octaneFeatureLocator) {
+    String classname = element.getAttribute("classname");
+    if (classname.isEmpty() || classname.equals("EMPTY_NAME") || classname.equals("Unknown")) {
+      return Optional.empty();
+    }
+    if (octaneFeatureLocator != null && octaneFeatureLocator.length > 0) {
+      Optional<OctaneFeature> octaneFeatureOpt;
+      //first attempt to find OctaneFeature based on exact match of classname
+      try {
+        octaneFeatureOpt = octaneFeatureLocator[0].getOctaneFeatureByName(classname);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      if (octaneFeatureOpt.isPresent()) {
+        return Optional.of(classname);
+      } else {
+        //attempt to find OctaneFeature based on match of classnamePart (removes hyphenated suffix)
+        String classnamePart = classname;
+        while (classnamePart.contains("-")) {
+          int lastIndex = classnamePart.lastIndexOf("-");
+          classnamePart = classnamePart.substring(0, lastIndex).trim();
+          try {
+            octaneFeatureOpt = octaneFeatureLocator[0].getOctaneFeatureByName(classnamePart);
+
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+          if (octaneFeatureOpt.isPresent()) {
+            return Optional.of(classnamePart);
             }
         }
-        return Optional.of(classname);
+      }
     }
+    return Optional.of(classname);
+  }
 
     @Override
     public Optional<String> getFeatureFile() {

--- a/src/test/java/com/microfocus/bdd/ut/TestCucumberJvmHandler.java
+++ b/src/test/java/com/microfocus/bdd/ut/TestCucumberJvmHandler.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Iterator;
 
 public class TestCucumberJvmHandler {
@@ -230,5 +231,36 @@ public class TestCucumberJvmHandler {
         Assert.assertTrue("handler doesn't return feature name",
                 !handler.getFeatureName().isPresent());
     }
+
+  @Test
+  public void testHyphenatedFeatureNameExactMatch() {
+    CucumberJvmHandler handler = new CucumberJvmHandler();
+    Element element = TestUtil.getXmlElement("src/test/resources/cucumber-jvm/hyphenated-feature-name/TEST-hyphenated-feature-name.xml",
+        "testcase", 1);
+    handler.setElement(element);
+    OctaneFeatureLocator cache = new OctaneFeatureLocator(Arrays.asList(
+        "src/test/resources/features/robustgherkin.feature", // this file is to add some salt to the test case
+        "src/test/resources/features/robustgherkin_cn.feature",// this file is to add some salt to the test case
+        "src/test/resources/features/feature_name_has_hyphens.feature"));
+    Assert.assertEquals("handler can get back feature name",
+        "feature - with hyphens - group one",
+        handler.getFeatureName(cache).get());
+
+  }
+  @Test
+  public void testHyphenatedFeatureNamePartMatch()  {
+    CucumberJvmHandler handler = new CucumberJvmHandler();
+    Element element = TestUtil.getXmlElement("src/test/resources/cucumber-jvm/hyphenated-feature-name/TEST-hyphenated-feature-name.xml",
+        "testcase", 2);
+    handler.setElement(element);
+    OctaneFeatureLocator cache = new OctaneFeatureLocator(Arrays.asList(
+        "src/test/resources/features/robustgherkin.feature", // this file is to add some salt to the test case
+        "src/test/resources/features/robustgherkin_cn.feature",// this file is to add some salt to the test case
+        "src/test/resources/features/feature_name_has_hyphens.feature"));
+    Assert.assertEquals("handler can get back feature name",
+        "feature - with hyphens - group one",
+        handler.getFeatureName(cache).get());
+
+  }
 
 }

--- a/src/test/resources/cucumber-jvm/hyphenated-feature-name/TEST-hyphenated-feature-name.xml
+++ b/src/test/resources/cucumber-jvm/hyphenated-feature-name/TEST-hyphenated-feature-name.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite tests="4" failures="0" name="com.czeczotka.bdd.runner.RunCalculatorTest" time="0.109" errors="0" skipped="0">
+  <properties>
+    <property name="java.runtime.name" value="OpenJDK Runtime Environment"/>
+    <property name="java.vm.version" value="11.0.11+9"/>
+    <property name="sun.boot.library.path" value="C:\Program Files\AdoptOpenJDK\bin"/>
+    <property name="maven.multiModuleProjectDirectory" value="D:\userApps\cucumber-jvm-maven"/>
+    <property name="java.vm.vendor" value="AdoptOpenJDK"/>
+    <property name="java.vendor.url" value="https://adoptopenjdk.net/"/>
+    <property name="guice.disable.misplaced.annotation.check" value="true"/>
+    <property name="path.separator" value=";"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="sun.os.patch.level" value=""/>
+    <property name="user.script" value=""/>
+    <property name="user.country" value="US"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+    <property name="user.dir" value="D:\userApps\cucumber-jvm-maven"/>
+    <property name="java.vm.compressedOopsMode" value="Zero based"/>
+    <property name="java.runtime.version" value="11.0.11+9"/>
+    <property name="java.awt.graphicsenv" value="sun.awt.Win32GraphicsEnvironment"/>
+    <property name="os.arch" value="amd64"/>
+    <property name="java.io.tmpdir" value="C:\Users\QIUXIA~1.COR\AppData\Local\Temp\"/>
+    <property name="line.separator" value="
+"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="user.variant" value=""/>
+    <property name="os.name" value="Windows 10"/>
+    <property name="classworlds.conf" value="C:\apache-maven-3.5.0\bin\..\bin\m2.conf"/>
+    <property name="sun.jnu.encoding" value="Cp1252"/>
+    <property name="java.library.path" value="C:\Program Files\AdoptOpenJDK\bin;C:\WINDOWS\Sun\Java\bin;C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files\7-Zip\;C:\Program Files\AdoptOpenJDK\bin;C:\Program Files (x86)\Yarn\bin\;C:\hack_proj\msteams-samples-hello-world-nodejs-master\node_modules\.bin;C:\Apps\mqm\UI\mqm-web-ui\node_modules\.bin;C:\Program Files\nodejs\node_modules\npm;C:\Program Files\Java\jdk1.8.0_211\bin;C:\apache-maven-3.5.0\bin;C:\Program Files (x86)\Common Files\Oracle\Java\javapath;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Users\qiuxiao\MFRepository\mqm\UI\mqm-web-ui\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Intel\WiFi\bin\;C:\Program Files\Common Files\Intel\WirelessCommon\;C:\ProgramData\chocolatey\bin;C:\Program Files\nodejs\;C:\Program Files\Docker\Docker\resources\bin;C:\ProgramData\DockerDesktop\version-bin;;C:\Program Files (x86)\Gpg4win\..\GnuPG\bin;C:\Ruby27-x64\bin;C:\Users\qiuxiao.CORPDOM\AppData\Local\Yarn\bin;C:\Users\qiuxiao.CORPDOM\AppData\Local\Microsoft\WindowsApps;C:\Users\qiuxiao.CORPDOM\AppData\Local\GitHubDesktop\bin;C:\Program Files\JetBrains\IntelliJ IDEA 2019.1.3\bin;;C:\Users\qiuxiao.CORPDOM\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\qiuxiao.CORPDOM\AppData\Roaming\npm;C:\Users\qiuxiao.CORPDOM\AppData\Local\Microsoft\WindowsApps;."/>
+    <property name="maven.conf" value="C:\apache-maven-3.5.0\bin\../conf"/>
+    <property name="jdk.debug" value="release"/>
+    <property name="java.class.version" value="55.0"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="os.version" value="10.0"/>
+    <property name="library.jansi.path" value="C:\apache-maven-3.5.0\bin\..\lib\jansi-native\windows64"/>
+    <property name="user.home" value="C:\Users\qiuxiao.CORPDOM"/>
+    <property name="user.timezone" value="Asia/Shanghai"/>
+    <property name="java.awt.printerjob" value="sun.awt.windows.WPrinterJob"/>
+    <property name="file.encoding" value="Cp1252"/>
+    <property name="java.specification.version" value="11"/>
+    <property name="user.name" value="qiuxiao"/>
+    <property name="java.class.path" value="C:\apache-maven-3.5.0\bin\..\boot\plexus-classworlds-2.5.2.jar"/>
+    <property name="java.vm.specification.version" value="11"/>
+    <property name="sun.arch.data.model" value="64"/>
+    <property name="sun.java.command" value="org.codehaus.plexus.classworlds.launcher.Launcher test"/>
+    <property name="java.home" value="C:\Program Files\AdoptOpenJDK"/>
+    <property name="user.language" value="en"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="awt.toolkit" value="sun.awt.windows.WToolkit"/>
+    <property name="java.vm.info" value="mixed mode"/>
+    <property name="java.version" value="11.0.11"/>
+    <property name="java.vendor" value="AdoptOpenJDK"/>
+    <property name="sun.stderr.encoding" value="cp437"/>
+    <property name="maven.home" value="C:\apache-maven-3.5.0\bin\.."/>
+    <property name="file.separator" value="\"/>
+    <property name="java.version.date" value="2021-04-20"/>
+    <property name="java.vendor.url.bug" value="https://github.com/AdoptOpenJDK/openjdk-support/issues"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="java.vendor.version" value="AdoptOpenJDK-11.0.11+9"/>
+    <property name="sun.stdout.encoding" value="cp437"/>
+    <property name="sun.desktop" value="windows"/>
+    <property name="sun.cpu.isalist" value="amd64"/>
+  </properties>
+  <testcase classname="feature - with hyphens - group one" name="Some determinable business situation (hyphenated feature name)" time="0.047"/>
+  <testcase classname="feature - with hyphens - group one - some extra text" name="Some another scenario 2 (hyphenated feature name)" time="0.021"/>
+</testsuite>

--- a/src/test/resources/features/feature_name_has_hyphens.feature
+++ b/src/test/resources/features/feature_name_has_hyphens.feature
@@ -1,0 +1,36 @@
+@billing @bicker @annoy
+Feature: feature - with hyphens - group one
+  A description with
+  multiple
+  lines
+
+  Background:
+    Given a global administrator named "Greg"
+    * a blog named "Greg's anti-tax rants"
+    * a customer named "Wilson"
+
+  @Quick @full @annoy
+  Scenario: Some determinable business situation (hyphenated feature name)
+    Given the following people exist:
+      | name  | email           | phone |
+      | Aila  | aila@email.com  | 123   |
+      | Joe   | joe@email.com   | 234   |
+    And some precondition 1
+    When some action by the actor
+    And some other action
+    Then some testable outcome is achieved
+    And something else we can check happens too
+
+  @Quick @nightly
+  Scenario: Some another scenario 2 (hyphenated feature name)
+  scenario 2 description
+    Given some precondition
+    And some other precondition with doc string
+		"""
+		this is comment
+		"""
+    When some action by the actor
+    And yet another action
+    Then some testable outcome is achieved
+    * something else we can check happens too
+    But I don't see something else


### PR DESCRIPTION
To ensure the correct feature is found, first search for an exact match of feature description and classname.  Only if this is not successful does the current logic to check for part matches (excluding hyphenated suffix) apply.