### PR TITLE
defect #2612043: Azure DevOps pipeline execution issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   
   <groupId>com.microfocus.adm.almoctane.bdd</groupId>
   <artifactId>bdd2octane</artifactId>
-  <version>1.1.8-SNAPSHOT</version>
+  <version>1.1.9-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>bdd2octane</name>

--- a/src/main/java/com/microfocus/bdd/JunitReportReader.java
+++ b/src/main/java/com/microfocus/bdd/JunitReportReader.java
@@ -89,6 +89,10 @@ public class JunitReportReader implements Iterable<Element>{
         }
 
         private Element getElement(StartElement startElementEvent) {
+            if (null == startElementEvent) {
+                return null;
+            }
+
             Element element = new Element();
             try {
                 String elementName = getElementName(startElementEvent);


### PR DESCRIPTION
## Backlog item
Defect #[2612043](https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2612043): Azure DevOps pipeline execution issues

## Description
For test result files with an empty test suite, there won't be any initial element. That's because we're looking for testcases to set the initial element. In this case, we should simply skip the processing by returning from the method when the `startElementEvent` is `null`.