### PR TITLE
Remove hardcoded GPG passphrase from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,9 @@
   <profiles>
     <profile>
       <id>sign</id>
+      <properties>
+        <gpg.executable>gpg2</gpg.executable>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -367,17 +370,6 @@
           <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
       </distributionManagement>
-    </profile>
-
-    <profile>
-      <id>ossrh</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <gpg.executable>gpg2</gpg.executable>
-        <gpg.passphrase>https://github.com/HPSoftware/bdd2octane</gpg.passphrase>
-      </properties>
     </profile>
 
   </profiles>


### PR DESCRIPTION
## Summary
- Removed the `ossrh` Maven profile which contained a hardcoded `gpg.passphrase` value in source control, active by default on every build
- Moved `gpg.executable=gpg2` to the `sign` profile where it's actually used
- GPG passphrases should be provided via `~/.m2/settings.xml` or environment variables, not committed to the repository

## Context
The passphrase value (`https://github.com/HPSoftware/bdd2octane`) was a copy-paste artifact from another project (introduced in `38de43bf`, 2021-11-25) — not a real secret — but hardcoding credentials in pom.xml is a bad practice that should be cleaned up.

## Verification
- `mvn clean install` — builds and unit tests pass (integration test failure is pre-existing on master, unrelated)
- `sign` profile correctly picks up `gpg.executable=gpg2`