### PR TITLE
Fix XXE vulnerability in JunitReportReader

### DIFF
--- a/src/main/java/com/microfocus/bdd/JunitReportReader.java
+++ b/src/main/java/com/microfocus/bdd/JunitReportReader.java
@@ -49,6 +49,8 @@ public class JunitReportReader implements Iterable<Element>{
 
     public JunitReportReader(InputStream inputStream, String testcaseElementName) throws XMLStreamException {
         XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         reader = xmlInputFactory.createXMLEventReader(inputStream, StandardCharsets.UTF_8.name());
         this.testcaseElementName = testcaseElementName;
         iterator = new ElementIterator();


### PR DESCRIPTION
## Summary
- Disabled external entity resolution and DTD processing in JunitReportReader's XML parser
- Prevents two attack vectors: arbitrary file read via external entities, and denial of service via entity expansion (billion laughs)

## Context
The XMLInputFactory was created with default settings since the initial commit (c71ed1f, 2021-11-15). Java's defaults enable DTD processing and external entity resolution, which is a known XXE vulnerability (OWASP Top 10).

The fix adds two properties before creating the reader:
```java
xmlInputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
```

## Verification
- Both attack vectors confirmed exploitable before the fix, blocked after
- Full test suite passes (44 tests, 0 failures)